### PR TITLE
Included the config.hxx file in log4CPlus source tree.

### DIFF
--- a/Smr/thirdParty/Universal/log4cplus-1.2.0/include/log4cplus/config.hxx
+++ b/Smr/thirdParty/Universal/log4cplus-1.2.0/include/log4cplus/config.hxx
@@ -24,15 +24,17 @@
 #ifndef LOG4CPLUS_CONFIG_HXX
 #define LOG4CPLUS_CONFIG_HXX
 
+//#if(defined(__APPLE__) && defined(__MACH__))
+//#define __MWERKS__
+//#define __MACOS__
+//#endif
+
 #if defined (_WIN32)
 #  include <log4cplus/config/win32.h>
-//#elif (defined(__MWERKS__) && defined(__MACOS__))
-#elif(defined(__APPLE__) && defined(__MACH__))
-#elif ()
+#elif (defined(__MWERKS__) && defined(__MACOS__))
 #  include <log4cplus/config/macosx.h>
 #else
 #  include <log4cplus/config/defines.hxx>
-//#  include <log4cplus/config/macosx.h>
 #endif
 
 #if ! defined (UNICODE) && ! defined (LOG4CPLUS_HAVE_VSNPRINTF_S) \

--- a/Smr/thirdParty/Universal/log4cplus-1.2.0/include/log4cplus/config/defines.hxx
+++ b/Smr/thirdParty/Universal/log4cplus-1.2.0/include/log4cplus/config/defines.hxx
@@ -1,0 +1,291 @@
+#ifndef LOG4CPLUS_CONFIG_DEFINES_HXX
+#define LOG4CPLUS_CONFIG_DEFINES_HXX
+
+/* */
+#define LOG4CPLUS_HAVE_SYSLOG_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_ARPA_INET_H 1
+
+/* */
+/* #undef LOG4CPLUS_HAVE_ATOMIC_H */
+
+/* */
+#define LOG4CPLUS_HAVE_NETINET_IN_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_NETINET_TCP_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_SYS_TIMEB_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_SYS_TIME_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_SYS_TYPES_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_SYS_STAT_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_SYS_SYSCALL_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_SYS_FILE_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_TIME_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_SYS_SOCKET_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_NETDB_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_UNISTD_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_FCNTL_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_STDARG_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_STDIO_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_STDLIB_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_ERRNO_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_WCHAR_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_ICONV_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_LIMITS_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_FTIME 1
+
+/* */
+#define LOG4CPLUS_HAVE_GETADDRINFO 1
+
+/* */
+/* #undef LOG4CPLUS_HAVE_GETHOSTBYNAME_R */
+
+/* */
+#define LOG4CPLUS_HAVE_GETPID 1
+
+/* */
+#define LOG4CPLUS_HAVE_GETTIMEOFDAY 1
+
+/* Define to 1 if you have the `clock_gettime' function. */
+/* #undef LOG4CPLUS_HAVE_CLOCK_GETTIME */
+
+/* Define to 1 if you have the `nanosleep' function. */
+#define LOG4CPLUS_HAVE_NANOSLEEP 1
+
+/* Define to 1 if you have the `clock_nanosleep' function. */
+/* #undef LOG4CPLUS_HAVE_CLOCK_NANOSLEEP */
+
+/* */
+#define LOG4CPLUS_HAVE_GMTIME_R 1
+
+/* */
+#define LOG4CPLUS_HAVE_HTONL 1
+
+/* */
+#define LOG4CPLUS_HAVE_HTONS 1
+
+/* */
+#define LOG4CPLUS_HAVE_LOCALTIME_R 1
+
+/* */
+#define LOG4CPLUS_HAVE_LSTAT 1
+
+/* */
+#define LOG4CPLUS_HAVE_FCNTL 1
+
+/* */
+#define LOG4CPLUS_HAVE_LOCKF 1
+
+/* */
+#define LOG4CPLUS_HAVE_FLOCK 1
+
+/* */
+#define LOG4CPLUS_HAVE_NTOHL 1
+
+/* */
+#define LOG4CPLUS_HAVE_NTOHS 1
+
+/* Define to 1 if you have the `shutdown' function. */
+#define LOG4CPLUS_HAVE_SHUTDOWN 1
+
+/* */
+#define LOG4CPLUS_HAVE_PIPE 1
+
+/* */
+/* #undef LOG4CPLUS_HAVE_PIPE2 */
+
+/* */
+#define LOG4CPLUS_HAVE_POLL 1
+
+/* */
+#define LOG4CPLUS_HAVE_POLL_H 1
+
+/* */
+#define LOG4CPLUS_HAVE_STAT 1
+
+/* Define if this is a single-threaded library. */
+/* #undef LOG4CPLUS_SINGLE_THREADED */
+
+/* */
+/* #undef LOG4CPLUS_USE_PTHREADS */
+
+/* Define for compilers/standard libraries that support more than just the "C"
+   locale. */
+/* #undef LOG4CPLUS_WORKING_LOCALE */
+
+/* Define for C99 compilers/standard libraries that support more than just the
+   "C" locale. */
+/* #undef LOG4CPLUS_WORKING_C_LOCALE */
+
+/* Define so that log4cplus will use C++11 threads and synchronization
+   primitives. */
+/* #undef LOG4CPLUS_WITH_CXX11_THREADS */
+
+/* Define to int if undefined. */
+/* #undef socklen_t */
+
+/* Defined for --enable-debugging builds. */
+/* #undef LOG4CPLUS_DEBUGGING */
+
+/* Defined if the compiler understands __declspec(dllexport) or
+   __attribute__((visibility("default"))) construct. */
+#define LOG4CPLUS_DECLSPEC_EXPORT __attribute__ ((visibility("default")))
+
+/* Defined if the compiler understands __declspec(dllimport) or
+   __attribute__((visibility("default"))) construct. */
+#define LOG4CPLUS_DECLSPEC_IMPORT __attribute__ ((visibility("default")))
+
+/* Defined if the compiler understands
+   __attribute__((visibility("hidden"))) construct. */
+#define LOG4CPLUS_DECLSPEC_PRIVATE __attribute__ ((visibility("hidden")))
+
+/* */
+#define LOG4CPLUS_HAVE_TLS_SUPPORT 1
+
+/* */
+#define LOG4CPLUS_THREAD_LOCAL_VAR __thread
+
+/* Defined if the host OS provides ENAMETOOLONG errno value. */
+#define LOG4CPLUS_HAVE_ENAMETOOLONG 1
+
+/* Defined if the compiler provides __sync_add_and_fetch(). */
+#define LOG4CPLUS_HAVE___SYNC_ADD_AND_FETCH 1
+
+/* Defined if the compiler provides __sync_sub_and_fetch(). */
+#define LOG4CPLUS_HAVE___SYNC_SUB_AND_FETCH 1
+
+/* Defined if the compiler provides __atomic_add_fetch(). */
+/* #undef LOG4CPLUS_HAVE___ATOMIC_ADD_FETCH */
+
+/* Defined if the compiler provides __atomic_sub_fetch(). */
+/* #undef LOG4CPLUS_HAVE___ATOMIC_SUB_FETCH */
+
+/* Defined if atomic_inc_uint() is available. */
+/* #undef LOG4CPLUS_HAVE_ATOMIC_INC_UINT */
+
+/* Defined if atomic_dec_uint_nv() is available.  */
+/* #undef LOG4CPLUS_HAVE_ATOMIC_DEC_UINT_NV */
+
+/* Defined if the compiler provides C++11 <atomic> header and increment,
+   decrement operations. */
+/* #undef LOG4CPLUS_HAVE_CXX11_ATOMICS */
+
+/* */
+#define LOG4CPLUS_HAVE_C99_VARIADIC_MACROS 1
+
+/* */
+#define LOG4CPLUS_HAVE_GNU_VARIADIC_MACROS 1
+
+/* */
+#define LOG4CPLUS_HAVE_VSNPRINTF 1
+
+/* Define to 1 if you have the `vsnwprintf' function. */
+/* #undef LOG4CPLUS_HAVE_VSNWPRINTF */
+
+/* Define to 1 if you have the `_vsnwprintf' function. */
+/* #undef LOG4CPLUS_HAVE__VSNWPRINTF */
+
+/* */
+/* #undef LOG4CPLUS_HAVE__VSNPRINTF */
+
+/* Define to 1 if you have the `vfprintf_s' function. */
+/* #undef LOG4CPLUS_HAVE_VFPRINTF_S */
+
+/* Define to 1 if you have the `vfwprintf_s' function. */
+/* #undef LOG4CPLUS_HAVE_VFWPRINTF_S */
+
+/* Define to 1 if you have the `vsprintf_s' function. */
+/* #undef LOG4CPLUS_HAVE_VSPRINTF_S */
+
+/* Define to 1 if you have the `vswprintf_s' function. */
+/* #undef LOG4CPLUS_HAVE_VSWPRINTF_S */
+
+/* Define to 1 if you have the `_vsnprintf_s' function. */
+/* #undef LOG4CPLUS_HAVE__VSNPRINTF_S */
+
+/* Define to 1 if you have the `_vsnwprintf_s' function. */
+/* #undef LOG4CPLUS_HAVE__VSNWPRINTF_S */
+
+/* Defined if the compiler supports __FUNCTION__ macro. */
+#define LOG4CPLUS_HAVE_FUNCTION_MACRO 1
+
+/* Defined if the compiler supports __PRETTY_FUNCTION__ macro. */
+#define LOG4CPLUS_HAVE_PRETTY_FUNCTION_MACRO 1
+
+/* Defined if the compiler supports __func__ symbol. */
+#define LOG4CPLUS_HAVE_FUNC_SYMBOL 1
+
+/* Define to 1 if you have the `mbstowcs' function. */
+#define LOG4CPLUS_HAVE_MBSTOWCS 1
+
+/* Define to 1 if you have the `wcstombs' function. */
+#define LOG4CPLUS_HAVE_WCSTOMBS 1
+
+/* Define to 1 if you have Linux style syscall(SYS_gettid). */
+#define LOG4CPLUS_HAVE_GETTID 1
+
+/* Define when iconv() is available. */
+/* #undef LOG4CPLUS_WITH_ICONV */
+
+/* Define to 1 if you have the `iconv' function. */
+/* #undef LOG4CPLUS_HAVE_ICONV */
+
+/* Define to 1 if you have the `iconv_close' function. */
+/* #undef LOG4CPLUS_HAVE_ICONV_CLOSE */
+
+/* Define to 1 if you have the `iconv_open' function. */
+/* #undef LOG4CPLUS_HAVE_ICONV_OPEN */
+
+/* Define to 1 if you have the `OutputDebugString' function. */
+/* #undef LOG4CPLUS_HAVE_OUTPUTDEBUGSTRING */
+
+/* Define to 1 if the system has the `constructor' function attribute
+   with priority */
+/* #undef LOG4CPLUS_HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR_PRIORITY */
+
+/* Define to 1 if the system has the `constructor' function attribute */
+/* #undef LOG4CPLUS_HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR */
+
+/* Define to 1 if the system has the `init_priority' variable attribute */
+/* #undef LOG4CPLUS_HAVE_VAR_ATTRIBUTE_INIT_PRIORITY */
+
+#endif // LOG4CPLUS_CONFIG_DEFINES_HXX

--- a/Smr/thirdParty/Universal/log4cplus-1.2.0/include/log4cplus/config/defines.hxx.cmake
+++ b/Smr/thirdParty/Universal/log4cplus-1.2.0/include/log4cplus/config/defines.hxx.cmake
@@ -1,0 +1,291 @@
+#ifndef LOG4CPLUS_CONFIG_DEFINES_HXX
+#define LOG4CPLUS_CONFIG_DEFINES_HXX
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_SYSLOG_H @LOG4CPLUS_HAVE_SYSLOG_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_ARPA_INET_H @LOG4CPLUS_HAVE_ARPA_INET_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_ATOMIC_H @LOG4CPLUS_HAVE_ATOMIC_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_NETINET_IN_H @LOG4CPLUS_HAVE_NETINET_IN_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_NETINET_TCP_H @LOG4CPLUS_HAVE_NETINET_TCP_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_SYS_TIMEB_H @LOG4CPLUS_HAVE_SYS_TIMEB_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_SYS_TIME_H @LOG4CPLUS_HAVE_SYS_TIME_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_SYS_TYPES_H @LOG4CPLUS_HAVE_SYS_TYPES_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_SYS_STAT_H @LOG4CPLUS_HAVE_SYS_STAT_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_SYS_SYSCALL_H @LOG4CPLUS_HAVE_SYS_SYSCALL_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_SYS_FILE_H @LOG4CPLUS_HAVE_SYS_FILE_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_TIME_H @LOG4CPLUS_HAVE_TIME_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_SYS_SOCKET_H @LOG4CPLUS_HAVE_SYS_SOCKET_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_NETDB_H @LOG4CPLUS_HAVE_NETDB_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_UNISTD_H @LOG4CPLUS_HAVE_UNISTD_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_FCNTL_H @LOG4CPLUS_HAVE_FCNTL_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_STDARG_H @LOG4CPLUS_HAVE_STDARG_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_STDIO_H @LOG4CPLUS_HAVE_STDIO_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_STDLIB_H @LOG4CPLUS_HAVE_STDLIB_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_ERRNO_H @LOG4CPLUS_HAVE_ERRNO_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_WCHAR_H @LOG4CPLUS_HAVE_WCHAR_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_ICONV_H @LOG4CPLUS_HAVE_ICONV_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_LIMITS_H @LOG4CPLUS_HAVE_LIMITS_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_FTIME @LOG4CPLUS_HAVE_FTIME@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_GETADDRINFO @LOG4CPLUS_HAVE_GETADDRINFO@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_GETHOSTBYNAME_R @LOG4CPLUS_HAVE_GETHOSTBYNAME_R@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_GETPID @LOG4CPLUS_HAVE_GETPID@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_GETTIMEOFDAY @LOG4CPLUS_HAVE_GETTIMEOFDAY@
+
+/* Define to 1 if you have the `clock_gettime' function. */
+#cmakedefine LOG4CPLUS_HAVE_CLOCK_GETTIME @LOG4CPLUS_HAVE_CLOCK_GETTIME@
+
+/* Define to 1 if you have the `nanosleep' function. */
+#cmakedefine LOG4CPLUS_HAVE_NANOSLEEP @LOG4CPLUS_HAVE_NANOSLEEP@
+
+/* Define to 1 if you have the `clock_nanosleep' function. */
+#cmakedefine LOG4CPLUS_HAVE_CLOCK_NANOSLEEP @LOG4CPLUS_HAVE_CLOCK_NANOSLEEP@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_GMTIME_R @LOG4CPLUS_HAVE_GMTIME_R@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_HTONL @LOG4CPLUS_HAVE_HTONL@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_HTONS @LOG4CPLUS_HAVE_HTONS@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_LOCALTIME_R @LOG4CPLUS_HAVE_LOCALTIME_R@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_LSTAT @LOG4CPLUS_HAVE_LSTAT@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_FCNTL @LOG4CPLUS_HAVE_FCNTL@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_LOCKF @LOG4CPLUS_HAVE_LOCKF@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_FLOCK @LOG4CPLUS_HAVE_FLOCK@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_NTOHL @LOG4CPLUS_HAVE_NTOHL@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_NTOHS @LOG4CPLUS_HAVE_NTOHS@
+
+/* Define to 1 if you have the `shutdown' function. */
+#cmakedefine LOG4CPLUS_HAVE_SHUTDOWN @LOG4CPLUS_HAVE_SHUTDOWN@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_PIPE @LOG4CPLUS_HAVE_PIPE@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_PIPE2 @LOG4CPLUS_HAVE_PIPE2@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_POLL @LOG4CPLUS_HAVE_POLL@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_POLL_H @LOG4CPLUS_HAVE_POLL_H@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_STAT @LOG4CPLUS_HAVE_STAT@
+
+/* Define if this is a single-threaded library. */
+#cmakedefine LOG4CPLUS_SINGLE_THREADED @LOG4CPLUS_SINGLE_THREADED@
+
+/* */
+#cmakedefine LOG4CPLUS_USE_PTHREADS @LOG4CPLUS_USE_PTHREADS@
+
+/* Define for compilers/standard libraries that support more than just the "C"
+   locale. */
+#cmakedefine LOG4CPLUS_WORKING_LOCALE @LOG4CPLUS_WORKING_LOCALE@
+
+/* Define for C99 compilers/standard libraries that support more than just the
+   "C" locale. */
+#cmakedefine LOG4CPLUS_WORKING_C_LOCALE @LOG4CPLUS_WORKING_C_LOCALE@
+
+/* Define so that log4cplus will use C++11 threads and synchronization
+   primitives. */
+#cmakedefine LOG4CPLUS_WITH_CXX11_THREADS @LOG4CPLUS_WITH_CXX11_THREADS@
+
+/* Define to int if undefined. */
+#cmakedefine socklen_t @socklen_t@
+
+/* Defined for --enable-debugging builds. */
+#cmakedefine LOG4CPLUS_DEBUGGING @LOG4CPLUS_DEBUGGING@
+
+/* Defined if the compiler understands __declspec(dllexport) or
+   __attribute__((visibility("default"))) construct. */
+#cmakedefine LOG4CPLUS_DECLSPEC_EXPORT @LOG4CPLUS_DECLSPEC_EXPORT@
+
+/* Defined if the compiler understands __declspec(dllimport) or
+   __attribute__((visibility("default"))) construct. */
+#cmakedefine LOG4CPLUS_DECLSPEC_IMPORT @LOG4CPLUS_DECLSPEC_IMPORT@
+
+/* Defined if the compiler understands
+   __attribute__((visibility("hidden"))) construct. */
+#cmakedefine LOG4CPLUS_DECLSPEC_PRIVATE @LOG4CPLUS_DECLSPEC_PRIVATE@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_TLS_SUPPORT @LOG4CPLUS_HAVE_TLS_SUPPORT@
+
+/* */
+#cmakedefine LOG4CPLUS_THREAD_LOCAL_VAR @LOG4CPLUS_THREAD_LOCAL_VAR@
+
+/* Defined if the host OS provides ENAMETOOLONG errno value. */
+#cmakedefine LOG4CPLUS_HAVE_ENAMETOOLONG @LOG4CPLUS_HAVE_ENAMETOOLONG@
+
+/* Defined if the compiler provides __sync_add_and_fetch(). */
+#cmakedefine LOG4CPLUS_HAVE___SYNC_ADD_AND_FETCH @LOG4CPLUS_HAVE___SYNC_ADD_AND_FETCH@
+
+/* Defined if the compiler provides __sync_sub_and_fetch(). */
+#cmakedefine LOG4CPLUS_HAVE___SYNC_SUB_AND_FETCH @LOG4CPLUS_HAVE___SYNC_SUB_AND_FETCH@
+
+/* Defined if the compiler provides __atomic_add_fetch(). */
+#cmakedefine LOG4CPLUS_HAVE___ATOMIC_ADD_FETCH @LOG4CPLUS_HAVE___ATOMIC_ADD_FETCH@
+
+/* Defined if the compiler provides __atomic_sub_fetch(). */
+#cmakedefine LOG4CPLUS_HAVE___ATOMIC_SUB_FETCH @LOG4CPLUS_HAVE___ATOMIC_SUB_FETCH@
+
+/* Defined if atomic_inc_uint() is available. */
+#cmakedefine LOG4CPLUS_HAVE_ATOMIC_INC_UINT @LOG4CPLUS_HAVE_ATOMIC_INC_UINT@
+
+/* Defined if atomic_dec_uint_nv() is available.  */
+#cmakedefine LOG4CPLUS_HAVE_ATOMIC_DEC_UINT_NV @LOG4CPLUS_HAVE_ATOMIC_DEC_UINT_NV@
+
+/* Defined if the compiler provides C++11 <atomic> header and increment,
+   decrement operations. */
+#cmakedefine LOG4CPLUS_HAVE_CXX11_ATOMICS @LOG4CPLUS_HAVE_CXX11_ATOMICS@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_C99_VARIADIC_MACROS @LOG4CPLUS_HAVE_C99_VARIADIC_MACROS@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_GNU_VARIADIC_MACROS @LOG4CPLUS_HAVE_GNU_VARIADIC_MACROS@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE_VSNPRINTF @LOG4CPLUS_HAVE_VSNPRINTF@
+
+/* Define to 1 if you have the `vsnwprintf' function. */
+#cmakedefine LOG4CPLUS_HAVE_VSNWPRINTF @LOG4CPLUS_HAVE_VSNWPRINTF@
+
+/* Define to 1 if you have the `_vsnwprintf' function. */
+#cmakedefine LOG4CPLUS_HAVE__VSNWPRINTF @LOG4CPLUS_HAVE__VSNWPRINTF@
+
+/* */
+#cmakedefine LOG4CPLUS_HAVE__VSNPRINTF @LOG4CPLUS_HAVE__VSNPRINTF@
+
+/* Define to 1 if you have the `vfprintf_s' function. */
+#cmakedefine LOG4CPLUS_HAVE_VFPRINTF_S @LOG4CPLUS_HAVE_VFPRINTF_S@
+
+/* Define to 1 if you have the `vfwprintf_s' function. */
+#cmakedefine LOG4CPLUS_HAVE_VFWPRINTF_S @LOG4CPLUS_HAVE_VFWPRINTF_S@
+
+/* Define to 1 if you have the `vsprintf_s' function. */
+#cmakedefine LOG4CPLUS_HAVE_VSPRINTF_S @LOG4CPLUS_HAVE_VSPRINTF_S@
+
+/* Define to 1 if you have the `vswprintf_s' function. */
+#cmakedefine LOG4CPLUS_HAVE_VSWPRINTF_S @LOG4CPLUS_HAVE_VSWPRINTF_S@
+
+/* Define to 1 if you have the `_vsnprintf_s' function. */
+#cmakedefine LOG4CPLUS_HAVE__VSNPRINTF_S @LOG4CPLUS_HAVE__VSNPRINTF_S@
+
+/* Define to 1 if you have the `_vsnwprintf_s' function. */
+#cmakedefine LOG4CPLUS_HAVE__VSNWPRINTF_S @LOG4CPLUS_HAVE__VSNWPRINTF_S@
+
+/* Defined if the compiler supports __FUNCTION__ macro. */
+#cmakedefine LOG4CPLUS_HAVE_FUNCTION_MACRO @LOG4CPLUS_HAVE_FUNCTION_MACRO@
+
+/* Defined if the compiler supports __PRETTY_FUNCTION__ macro. */
+#cmakedefine LOG4CPLUS_HAVE_PRETTY_FUNCTION_MACRO @LOG4CPLUS_HAVE_PRETTY_FUNCTION_MACRO@
+
+/* Defined if the compiler supports __func__ symbol. */
+#cmakedefine LOG4CPLUS_HAVE_FUNC_SYMBOL @LOG4CPLUS_HAVE_FUNC_SYMBOL@
+
+/* Define to 1 if you have the `mbstowcs' function. */
+#cmakedefine LOG4CPLUS_HAVE_MBSTOWCS @LOG4CPLUS_HAVE_MBSTOWCS@
+
+/* Define to 1 if you have the `wcstombs' function. */
+#cmakedefine LOG4CPLUS_HAVE_WCSTOMBS @LOG4CPLUS_HAVE_WCSTOMBS@
+
+/* Define to 1 if you have Linux style syscall(SYS_gettid). */
+#cmakedefine LOG4CPLUS_HAVE_GETTID @LOG4CPLUS_HAVE_GETTID@
+
+/* Define when iconv() is available. */
+#cmakedefine LOG4CPLUS_WITH_ICONV @LOG4CPLUS_WITH_ICONV@
+
+/* Define to 1 if you have the `iconv' function. */
+#cmakedefine LOG4CPLUS_HAVE_ICONV @LOG4CPLUS_HAVE_ICONV@
+
+/* Define to 1 if you have the `iconv_close' function. */
+#cmakedefine LOG4CPLUS_HAVE_ICONV_CLOSE @LOG4CPLUS_HAVE_ICONV_CLOSE@
+
+/* Define to 1 if you have the `iconv_open' function. */
+#cmakedefine LOG4CPLUS_HAVE_ICONV_OPEN @LOG4CPLUS_HAVE_ICONV_OPEN@
+
+/* Define to 1 if you have the `OutputDebugString' function. */
+#cmakedefine LOG4CPLUS_HAVE_OUTPUTDEBUGSTRING @LOG4CPLUS_HAVE_OUTPUTDEBUGSTRING@
+
+/* Define to 1 if the system has the `constructor' function attribute
+   with priority */
+#cmakedefine LOG4CPLUS_HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR_PRIORITY @LOG4CPLUS_HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR_PRIORITY@
+
+/* Define to 1 if the system has the `constructor' function attribute */
+#cmakedefine LOG4CPLUS_HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR @LOG4CPLUS_HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR@
+
+/* Define to 1 if the system has the `init_priority' variable attribute */
+#cmakedefine LOG4CPLUS_HAVE_VAR_ATTRIBUTE_INIT_PRIORITY @LOG4CPLUS_HAVE_VAR_ATTRIBUTE_INIT_PRIORITY@
+
+#endif // LOG4CPLUS_CONFIG_DEFINES_HXX


### PR DESCRIPTION
Included the config.hxx file in log4CPlus source tree.  

This file is normally created at compile time by the macros defined in Log4Cplus. These macros are executed when one builds log4Cplus. The resulting config.hxx is moved to the cmake build snapshot directory and the associated path is added to the include directives — unfortunately the include directives are correctly specified only when building Log4Cplus (other projects do not run the config.hxx code generating Macro ). SImply copying the file to the Log4CPlus source tree is a workaround. Alternatively (better option), the log4CPlus macro should also copy the file in the original log4CPlus source tree or the exact path of the generated config.hxx in the build directory should be referenced in the include directives.
